### PR TITLE
Fix subtle bug in default env-vars

### DIFF
--- a/dev-resources/envdef-configuration.yaml
+++ b/dev-resources/envdef-configuration.yaml
@@ -1,1 +1,2 @@
-magic: ${XYZZYX:plugh}
+use-default: ${XYZZYX:default-plugh}
+use-env: ${HOME:not-home}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.aviso/config "0.1.3"
+(defproject io.aviso/config "0.1.4"
             :description "Configure a system using YAML or EDN files"
             :url "https://github.com/AvisoNovate/config"
             :license {:name "Apache Sofware License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.aviso/config "0.1.4"
+(defproject io.aviso/config "0.1.5"
             :description "Configure a system using YAML or EDN files"
             :url "https://github.com/AvisoNovate/config"
             :license {:name "Apache Sofware License 2.0"

--- a/spec/config_specs.clj
+++ b/spec/config_specs.clj
@@ -90,7 +90,8 @@
   (it "can use a default value on an environment variable"
       (->> (assemble-configuration {:prefix "envdef"
                                     :schemas [{s/Any s/Any}]})
-           (should= {:magic "plugh"})))
+           (should= {:use-default "default-plugh"
+                     :use-env     (System/getenv "HOME")})))
 
   (it "can associate and extract schemas"
       (->> [(with-config-schema {} WebServer)

--- a/src/io/aviso/config.clj
+++ b/src/io/aviso/config.clj
@@ -33,7 +33,7 @@
   [^String env-ref]
   (let [x (.indexOf env-ref ":")]
     (if (pos? x)
-      [(subs env-ref x)
+      [(subs env-ref 0 x)
        (subs env-ref (inc x))]
       [env-ref])))
 


### PR DESCRIPTION
There was a subtle bug in the re-written default env-var implementation. Basically, what would happen is if there was a default provided, it would _always_ choose the default, even if the actual environment variable was present.
