### PR TITLE
Fix HTML rendered documentation

### DIFF
--- a/src/io/aviso/config.clj
+++ b/src/io/aviso/config.clj
@@ -5,7 +5,7 @@
 
       <prefix>-<profile>-configuration.<extension>
 
-  The <prefix> is specific to the application; the profile is provided by the application.
+  The prefix is specific to the application; the profile is provided by the application.
 
   Currently, the extensions \"yaml\" and \"edn\" are supported.
 


### PR DESCRIPTION
The usage of angle brackets resulted in `<prefix>` missing in the HTML rendered documentation at http://howardlewisship.com/io.aviso/config/io.aviso.config.html#top
