### PR TITLE
updates spec references to clojure.spec.alpha

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                              [io.aviso/logging "0.2.0"]
                              [criterium "0.4.4"]]}}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clojure-future-spec "1.9.0-alpha14"]
+                 [clojure-future-spec "1.9.0-beta4"]
                  [com.stuartsierra/component "0.3.2"]]
   :plugins [[speclj "3.3.2"]
             [lein-codox "0.10.2"]]

--- a/spec/config_specs.clj
+++ b/spec/config_specs.clj
@@ -4,8 +4,8 @@
   (:require [com.stuartsierra.component :as component]
             [clojure.future :refer [int?
                                     simple-keyword?]]
-            [clojure.spec :as s]
-            [clojure.spec.test :as stest])
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest])
   (:import (clojure.lang ExceptionInfo)))
 
 

--- a/src/io/aviso/config.clj
+++ b/src/io/aviso/config.clj
@@ -14,7 +14,7 @@
             [clojure.string :as str]
             [clojure.java.io :as io]
             [com.stuartsierra.component :as component]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [com.stuartsierra.dependency :as dep])
   (:import (java.io PushbackReader)))
 


### PR DESCRIPTION
sadly this is a breaking change, but everyone else is in the same boat

fixes #10